### PR TITLE
wpcf7_add_shortcode is deprecated.

### DIFF
--- a/cf7-autocomplete.php
+++ b/cf7-autocomplete.php
@@ -64,7 +64,7 @@ class TB_Autocomplete{
 	}	
 
 	public function tb_shortcode_add() {		
-		wpcf7_add_shortcode(array( 'autocomplete', 'autocomplete*'), array($this, 'shortcode_handler'), true);
+		wpcf7_add_form_tag(array( 'autocomplete', 'autocomplete*'), array($this, 'shortcode_handler'), true);
 	}	
 
 	public function activation_hook() {


### PR DESCRIPTION
wpcf7_add_shortcode() → wpcf7_add_form_tag()
https://contactform7.com/2016/12/03/contact-form-7-46/